### PR TITLE
feat: avatar command

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -1,40 +1,40 @@
-require("dotenv").config()
-const fs = require("fs")
-const { Client, GatewayIntentBits, Collection } = require("discord.js")
-const Database = require("./config/Database")
+require("dotenv").config();
+const fs = require("fs");
+const { Client, GatewayIntentBits, Collection } = require("discord.js");
+const Database = require("./config/Database");
 
 //Connecting to MongoDB
-const db = new Database()
-db.connect()
+const db = new Database();
+db.connect();
 const client = new Client({
-  intents: [GatewayIntentBits.Guilds],
-})
+    intents: [GatewayIntentBits.Guilds],
+});
 
 //Command handler
 const commandFiles = fs
-  .readdirSync("./src/commands")
-  .filter((file) => file.endsWith(".js"))
-const commands = []
+    .readdirSync("./src/commands")
+    .filter((file) => file.endsWith(".js"));
+const commands = [];
 
 //deploying commands in Discord's API
-client.commands = new Collection()
+client.commands = new Collection();
 for (const file of commandFiles) {
-  const command = require(`./commands/${file}`)
-  commands.push(command.data.toJSON())
-  client.commands.set(command.data.name, command)
+    const command = require(`./commands/${file}`);
+    commands.push(command.data.toJSON());
+    client.commands.set(command.data.name, command);
 }
 
 //Event Handler
 const eventFiles = fs
-  .readdirSync("./src/events")
-  .filter((file) => file.endsWith(".js"))
+    .readdirSync("./src/events")
+    .filter((file) => file.endsWith(".js"));
 for (const file of eventFiles) {
-  const event = require(`./events/${file}`)
-  if (event.once) {
-    client.once(event.name, (...args) => event.execute(...args, commands))
-  } else {
-    client.on(event.name, (...args) => event.execute(...args, commands))
-  }
+    const event = require(`./events/${file}`);
+    if (event.once) {
+        client.once(event.name, (...args) => event.execute(...args, commands));
+    } else {
+        client.on(event.name, (...args) => event.execute(...args, commands));
+    }
 }
 
-client.login(process.env.token)
+client.login(process.env.token);

--- a/src/commands/avatar.js
+++ b/src/commands/avatar.js
@@ -1,0 +1,34 @@
+const { SlashCommandBuilder } = require("discord.js");
+const { EmbedBuilder } = require("discord.js");
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName("avatar")
+        .setDescription("Display the avatar of the user")
+        .addUserOption((option) =>
+            option
+                .setName(`user`)
+                .setDescription(`Select a user`)
+                .setRequired(false)
+        ),
+    async execute(interaction) {
+        const userMention =
+            interaction.options.getUser(`user`) || interaction.user;
+        const avatar = userMention.displayAvatarURL({
+            size: 1024,
+            extension: "png",
+        });
+
+        const embed = new EmbedBuilder()
+            .setColor("#00ffff")
+            .setAuthor({
+                name: `${userMention.tag}'s avatar`,
+                iconURL: `${userMention.displayAvatarURL()}`,
+            })
+            .setTitle(`Download`)
+            .setURL(avatar)
+            .setImage(avatar);
+
+        const message = await interaction.reply({ embeds: [embed] });
+    },
+};


### PR DESCRIPTION
Added a command that fetches the user avatar as requested in #54 

---

Slash Command options: 
- username

`Required` set to `false`, so
- if present:  will fetch the avatar of the user in the option
- else the avatar of the user who runs the command.

---

PS: I have `prettier` extension installed on my IDE, so it modified `bot.js` file. If you want, I can remove this.